### PR TITLE
next page가 restart면 / 로 가도록 변경

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -46,7 +46,7 @@ $("#login_btn").click(function(e) {
     success: function (data) {
       if (data == 'redirect') {
         next = document.getElementById("next").value;
-        if (next == 'None') {
+        if (next == 'None' || next == '/system/restart') {
           next = '/'
         }
         window.location.href = next;


### PR DESCRIPTION
http://sjva주소:9999/login?next=%2Fsystem%2Frestart
nginx 설정후 재시작 완료시 크롬 자동새로고침에 의해 해당 로그인 페이지가 뜨게되는데, 이 경우, 
로그인을 완료하면 다시 재시작을 실시하는 현상이 발생함